### PR TITLE
fix: Phase 0 live-bug batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,6 @@ lux.cmd
 state/*
 debug/*
 lua/config/lazy.lua.backup
-lazy-lock.json
-LuxVim/lazy-lock.json
 lesshst
 
 # OS - macOS

--- a/install.sh
+++ b/install.sh
@@ -292,8 +292,8 @@ while kill -0 "$SYNC_PID" 2>/dev/null; do
 done
 tput cnorm 2>/dev/null
 
-wait "$SYNC_PID" || true
-SYNC_EXIT=$?
+SYNC_EXIT=0
+wait "$SYNC_PID" || SYNC_EXIT=$?
 
 if [ "$SYNC_EXIT" -eq 0 ]; then
     PLUGIN_COUNT=$(grep -c "Finished task clone" "$LOG_FILE" 2>/dev/null || echo "0")

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,0 +1,14 @@
+{
+  "fzf": { "branch": "master", "commit": "f5fbfd848ec0a5c9771dd103e921e7064445c9ba" },
+  "fzf.vim": { "branch": "master", "commit": "356608e2ae5d9127e2c964885ea2b21ea7aea9ab" },
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "nvim-lspconfig": { "branch": "master", "commit": "ed19590a3a9792901553c388d1aadafce012f80d" },
+  "nvim-luxdash": { "branch": "main", "commit": "58d7586521c6e156c0bbeae89e0ff78ff9126da8" },
+  "nvim-luxline": { "branch": "main", "commit": "0d370d47e650aa2b05032e73b94791e8ccf6b92a" },
+  "nvim-tree.lua": { "branch": "master", "commit": "82f58063d67defc620e1ef8be606fc62a7b5dc1e" },
+  "nvim-treesitter": { "branch": "main", "commit": "4916d6592ede8c07973490d9322f187e07dfefac" },
+  "nvim-web-devicons": { "branch": "master", "commit": "dfbfaa967a6f7ec50789bead7ef87e336c1fa63c" },
+  "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
+  "vim-luxpane": { "branch": "main", "commit": "b3da76d6fe37e79d6ff35941d589fa7231228e3b" },
+  "whisk.nvim": { "branch": "main", "commit": "852b6892f4fe0a8f911843e0b90bfc947d3b95df" }
+}

--- a/lua/plugins/terminal/_defaults.lua
+++ b/lua/plugins/terminal/_defaults.lua
@@ -1,3 +1,1 @@
-return {
-  cmd = true,
-}
+return {}

--- a/lua/plugins/ui/config/theme-picker.lua
+++ b/lua/plugins/ui/config/theme-picker.lua
@@ -331,7 +331,7 @@ local function on_uninstall()
   render()
 end
 
-function open()
+local function open()
   _original_colorscheme = vim.g.colors_name
   build_items()
 

--- a/lua/types/plugin.lua
+++ b/lua/types/plugin.lua
@@ -20,10 +20,14 @@
 ---@field dependencies? any[] References to other plugin specs
 ---@field enabled? boolean Enable/disable plugin
 ---@field event? string|any[] Lazy-load on event
+---@field extends? string Name of framework spec to extend (deep merge)
 ---@field ft? string|any[] Lazy-load on filetype
+---@field globals? table vim.g variables set before plugin loads
+---@field keys? string|any[]|table Lazy-load on keymap
 ---@field lazy? table Lazy.nvim native fields
 ---@field opts? table Options passed to setup()
----@field source string GitHub repo (author/name)
+---@field replaces? string Name of framework spec to replace entirely
+---@field source string GitHub repo (author/name) or 'virtual'
 
 ---@class KeymapEntry
 ---@field action string Action to invoke
@@ -31,6 +35,7 @@
 ---@field mode? string|any[] Vim mode(s)
 
 ---@class AutocmdEntry
----@field action string Action to invoke
+---@field action? string Action to invoke (mutually exclusive with callback)
+---@field callback? function Direct callback (mutually exclusive with action)
 ---@field once? boolean Run only once
 ---@field pattern? string|any[] File pattern


### PR DESCRIPTION
Fixes the five verified live bugs from the improvement-program analysis:

- install.sh: capture plugin-sync exit code (failure branch was dead code)
- Track lazy-lock.json for reproducible installs and CI
- Remove schema-invalid cmd=true default from terminal category
- Regenerate stale lua/types/plugin.lua from current schema
- Scope theme-picker open() as local (global namespace leak)

No structural or behavioral changes beyond the listed fixes. Spec: docs/superpowers/specs/2026-07-06-luxvim-improvement-program-design.md (Section 3).