### PR TITLE
[codex] fix debug plugin main inference

### DIFF
--- a/lua/core/lib/pipeline/transform.lua
+++ b/lua/core/lib/pipeline/transform.lua
@@ -1,4 +1,5 @@
 local debug_mod = require("core.lib.debug")
+local paths = require("core.lib.paths")
 local platform = require("core.lib.platform")
 local conditions = require("core.registry.conditions")
 local notify = require("core.lib.notify")
@@ -6,6 +7,55 @@ local notify = require("core.lib.notify")
 local M = {}
 
 local passthrough_fields = { "event", "cmd", "ft", "keys" }
+
+local function normname(name)
+  return tostring(name or "")
+    :lower()
+    :gsub("^n?vim%-", "")
+    :gsub("%.n?vim$", "")
+    :gsub("[%.%-]lua", "")
+    :gsub("[^a-z]+", "")
+end
+
+local function lua_modules(lua_dir)
+  local modules = {}
+  local handle = vim.uv.fs_scandir(lua_dir)
+  if not handle then
+    return modules
+  end
+
+  while true do
+    local name, entry_type = vim.uv.fs_scandir_next(handle)
+    if not name then
+      break
+    end
+
+    if entry_type == "file" and name:match("%.lua$") then
+      table.insert(modules, name:gsub("%.lua$", ""))
+    elseif entry_type == "directory" and vim.uv.fs_stat(paths.join(lua_dir, name, "init.lua")) then
+      table.insert(modules, name)
+    end
+  end
+
+  return modules
+end
+
+local function infer_debug_main(debug_name, debug_path)
+  local modules = lua_modules(paths.join(debug_path, "lua"))
+  local target = normname(debug_name)
+
+  for _, module in ipairs(modules) do
+    if normname(module) == target then
+      return module
+    end
+  end
+
+  if #modules == 1 then
+    return modules[1]
+  end
+
+  return nil
+end
 
 local function safe_eval(fn)
   local ok, result = pcall(fn)
@@ -103,8 +153,10 @@ function M.transform_one(spec, specs_by_name)
   local lazy_spec = {}
 
   if use_debug then
-    lazy_spec.dir = debug_mod.get_debug_path(debug_name)
+    local debug_path = debug_mod.get_debug_path(debug_name)
+    lazy_spec.dir = debug_path
     lazy_spec.name = debug_name .. "-debug"
+    lazy_spec.main = infer_debug_main(debug_name, debug_path)
   else
     lazy_spec[1] = spec.source
   end

--- a/tests/unit/core/lib/pipeline/transform_spec.lua
+++ b/tests/unit/core/lib/pipeline/transform_spec.lua
@@ -101,6 +101,44 @@ describe("pipeline.transform", function()
     debug_mod.get_debug_path = orig_path
   end)
 
+  it("sets main for renamed debug plugins from the original plugin name", function()
+    local helpers = require("tests.helpers")
+    local root, cleanup = helpers.tmpdir.new({
+      lua = {
+        luxmotion = {
+          ["init.lua"] = "return {}",
+        },
+        whisk = {
+          ["init.lua"] = "return {}",
+        },
+      },
+    })
+
+    local debug_mod = require("core.lib.debug")
+    local orig_has = debug_mod.has_debug_plugin
+    local orig_path = debug_mod.get_debug_path
+    debug_mod.has_debug_plugin = function(name)
+      return name == "whisk.nvim"
+    end
+    debug_mod.get_debug_path = function()
+      return root
+    end
+
+    local ok, result = pcall(function()
+      return transform.transform_one({ source = "josstei/whisk.nvim", opts = {} }, {})
+    end)
+
+    debug_mod.has_debug_plugin = orig_has
+    debug_mod.get_debug_path = orig_path
+    cleanup()
+
+    assert.is_true(ok)
+    assert.equal(root, result.dir)
+    assert.equal("whisk.nvim-debug", result.name)
+    assert.equal("whisk", result.main)
+    assert.is_true(result.config)
+  end)
+
   describe("transform_build", function()
     it("returns the cmd field for a plain table build", function()
       local cmd = transform.transform_build({ cmd = ":make" })


### PR DESCRIPTION
## Summary

Fixes local debug plugin loading when LuxVim renames a debug plugin spec with the `-debug` suffix.

The startup error was caused by lazy.nvim inferring the config module from `whisk.nvim-debug`, while the local debug plugin exposes `lua/whisk/init.lua`. LuxVim now infers the real module from the debug plugin lua directory and sets `main` on the generated lazy.nvim spec.

## Impact

- `whisk.nvim-debug` now loads with `main = "whisk"`.
- The `VeryLazy` startup popup for `Lua module not found for config of whisk.nvim-debug` is resolved.
- Normal non-debug plugin specs are unchanged.

## Validation

- `lux --headless "+Lazy load whisk.nvim-debug" +qa`
- active lazy registry inspection reported `whisk`
- normal interactive `lux` startup no longer showed the `VeryLazy` / `whisk.nvim-debug` error
- `stylua --check init.lua lua/ tests/`
- `selene init.lua lua/ tests/`
- `shellcheck --severity=warning install.sh scripts/test.sh scripts/validate.sh`
- `Invoke-ScriptAnalyzer -Path ./install.ps1 -Severity Warning -EnableExit`
- `./scripts/validate.sh`
- `./scripts/test.sh`